### PR TITLE
updated version to 3.1.1

### DIFF
--- a/images/neo4j/Dockerfile
+++ b/images/neo4j/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j:3.1.0-enterprise
+FROM neo4j:3.1.1-enterprise
 
 RUN apk add -U bind-tools && rm -f /var/cache/apk/*
 


### PR DESCRIPTION
Updated version in dockerfile to 3.1.1-enterprise

Steps to release afterwards:
```
./images/build.sh
./images/push.sh neo4j-dcos 1.0.0-3.1.1
```

Will open follow up PR for cleanup documentation and removing universe files.