### PR TITLE
Update to Neo4j 3.3.3

### DIFF
--- a/images/neo4j/Dockerfile
+++ b/images/neo4j/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j:3.1.2-enterprise
+FROM neo4j:3.3.3-enterprise
 
 RUN apk add -U bind-tools && rm -f /var/cache/apk/*
 

--- a/images/neo4j/init-dcos-neo4j.sh
+++ b/images/neo4j/init-dcos-neo4j.sh
@@ -1,20 +1,5 @@
 #!/bin/bash -eu
 
-# this should be removed when https://github.com/neo4j/docker-neo4j/pull/68 is merged
-setting() {
-    setting="${1}"
-    value="${2}"
-    file="neo4j.conf"
-
-    if [ -n "${value}" ]; then
-        if grep -q -F "${setting}=" conf/"${file}"; then
-            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
-        else
-            echo "${setting}=${value}" >>conf/"${file}"
-        fi
-    fi
-}
-
 extract_app_id() {
     # calculating dns name for service discovery, see https://docs.mesosphere.com/1.8/usage/service-discovery/dns-overview/
     parts=$(echo "$1" | tr "/" " ")
@@ -61,10 +46,7 @@ ip=`/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
 export NEO4J_causalClustering_discoveryAdvertisedAddress=$ip":5000"
 export NEO4J_causalClustering_transactionAdvertisedAddress=$ip":6000"
 export NEO4J_causalClustering_raftAdvertisedAddress=$ip":7000"
-export NEO4J_dbms_advertisedAddress=$ip
-
-# this should be removed when https://github.com/neo4j/docker-neo4j/pull/68 is merged
-setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
+export NEO4J_dbms_connector_bolt_advertised__address=$ip":7687"
 
 # wait 5 seconds for dns to
 echo "waiting 5 seconds for dns"


### PR DESCRIPTION
Starting example app with this branch results in:
```
waiting 5 seconds for dns
Calculating DNS name of CORE members for core
URL using for service discovery: neo4jcc.marathon.containerip.dcos.thisdcos.directory
no DNS record found for neo4jcc.marathon.containerip.dcos.thisdcos.directory
calculated initial discovery members: 9.0.3.130:5000,9.0.4.130:5000
Changed password for user 'neo4j'.
Active database: graph.db
Directories in use:
  home:         /var/lib/neo4j
  config:       /var/lib/neo4j/conf
  logs:         /var/lib/neo4j/logs
  plugins:      /var/lib/neo4j/plugins
  import:       /var/lib/neo4j/import
  data:         /var/lib/neo4j/data
  certificates: /var/lib/neo4j/certificates
  run:          /var/lib/neo4j/run
Starting Neo4j.
2018-03-18 19:34:56.989+0000 INFO  ======== Neo4j 3.3.3 ========
2018-03-18 19:34:57.027+0000 INFO  Starting...
2018-03-18 19:34:59.831+0000 INFO  Bolt enabled on 0.0.0.0:7687.
2018-03-18 19:34:59.840+0000 INFO  Initiating metrics...
2018-03-18 19:35:00.110+0000 INFO  My connection info: [
	Discovery:   listen=0.0.0.0:5000, advertised=9.0.2.130:5000,
	Transaction: listen=0.0.0.0:6000, advertised=9.0.2.130:6000, 
	Raft:        listen=0.0.0.0:7000, advertised=9.0.2.130:7000, 
	Client Connector Addresses: bolt://9.0.2.130:7687,http://localhost:7474,https://localhost:7473
]
2018-03-18 19:35:00.110+0000 INFO  Discovering cluster with initial members: [9.0.3.130:5000, 9.0.4.130:5000]
2018-03-18 19:35:00.110+0000 INFO  Attempting to connect to the other cluster members before continuing...
2018-03-18 19:35:50.301+0000 INFO  Started.
2018-03-18 19:35:50.493+0000 INFO  Mounted REST API at: /db/manage
2018-03-18 19:35:52.090+0000 INFO  Remote interface available at http://localhost:7474/
```

To fully support 3.3.3, we need to update proxy as well